### PR TITLE
feat: handle access syntax on multiple lines

### DIFF
--- a/lib/spitfire.ex
+++ b/lib/spitfire.ex
@@ -749,9 +749,15 @@ defmodule Spitfire do
 
     extra_meta = [from_brackets: true]
 
+    newlines =
+      case current_newlines(parser) || peek_newlines(parser, :eol) do
+        nil -> []
+        nl -> [newlines: nl]
+      end
+
     parser = parser |> next_token() |> eat_eol()
     closing = current_meta(parser)
-    meta = extra_meta ++ [{:closing, closing} | meta]
+    meta = extra_meta ++ newlines ++ [{:closing, closing} | meta]
 
     ast = {{:., meta, [Access, :get]}, meta, [lhs, rhs]}
 

--- a/lib/spitfire.ex
+++ b/lib/spitfire.ex
@@ -750,7 +750,7 @@ defmodule Spitfire do
     extra_meta = [from_brackets: true]
 
     newlines =
-      case current_newlines(parser) || peek_newlines(parser, :eol) do
+      case peek_newlines(parser, :eol) do
         nil -> []
         nl -> [newlines: nl]
       end

--- a/test/spitfire_test.exs
+++ b/test/spitfire_test.exs
@@ -28,7 +28,12 @@ defmodule SpitfireTest do
         "%{bar: :foo}[:bar]",
         "state.parent_meta[:line]",
         "@preferred_envs[task]",
-        "!!meta[:diff]"
+        "!!meta[:diff]",
+        ~S'''
+        foo[
+          :bar
+        ]
+        '''
       ]
 
       for code <- codes do

--- a/test/spitfire_test.exs
+++ b/test/spitfire_test.exs
@@ -29,6 +29,7 @@ defmodule SpitfireTest do
         "state.parent_meta[:line]",
         "@preferred_envs[task]",
         "!!meta[:diff]",
+        "foo[1]",
         ~S'''
         foo[
           :bar


### PR DESCRIPTION
Spitfire doesn't handle 

```elixir
foo[
  :bar
]
```