### PR TITLE
feat: adds &parse_with_comments/2 function

### DIFF
--- a/lib/spitfire.ex
+++ b/lib/spitfire.ex
@@ -2547,6 +2547,9 @@ defmodule Spitfire do
     end
   end
 
+  # Code taken from Code.string_to_quoted_with_comments in Elixir core
+  # Check it out here: https://github.com/elixir-lang/elixir/blob/12f62e49ca2399a15976d2051a2d7743dae48449/lib/elixir/lib/code.ex#L1327
+  # Consult Elixir's license here: https://github.com/elixir-lang/elixir/blob/main/LICENSE
   defp preserve_comments(line, column, tokens, comment, rest) do
     comments = Process.get(:code_formatter_comments)
 

--- a/test/spitfire_test.exs
+++ b/test/spitfire_test.exs
@@ -2431,8 +2431,45 @@ defmodule SpitfireTest do
     end
   end
 
+  describe "&parse_with_comments/2" do
+    test "returns the comments" do
+      code = ~S'''
+        # hello
+        # world
+        :foo
+      '''
+
+      assert {:ok, _ast, comments} = Spitfire.parse_with_comments(code)
+      assert [%{line: 1, text: "# hello"}, %{line: 2, text: "# world"}] = comments
+      assert Spitfire.parse_with_comments(code) == s2qwc(code)
+    end
+
+    test "returns the same comments as string_to_quoted_with_comments" do
+      code = ~S'''
+        # This is a comment
+        :foo # This is also a valid comment
+        defmodule Foo do
+          # I am a comment in the module
+          def foo() do
+            :foo # Another one
+          end
+        end
+        # Some more comments!
+      '''
+
+      assert Spitfire.parse_with_comments(code) == s2qwc(code)
+    end
+  end
+
   defp s2q(code, opts \\ []) do
     Code.string_to_quoted(code, Keyword.merge([columns: true, token_metadata: true, emit_warnings: false], opts))
+  end
+
+  defp s2qwc(code, opts \\ []) do
+    Code.string_to_quoted_with_comments(
+      code,
+      Keyword.merge([columns: true, token_metadata: true, emit_warnings: false], opts)
+    )
   end
 
   def print(ast) do


### PR DESCRIPTION
Adds a parse_with_comments function to spitfire.
This will return the comments in the same format as
`&Code.string_to_quoted_with_comments/2`. Needed in order to format back
the code with the same comments.