### PR TITLE
fix: match error case from `Macro.Env.expand_import/5`

### DIFF
--- a/lib/spitfire/env.ex
+++ b/lib/spitfire/env.ex
@@ -318,6 +318,9 @@ defmodule Spitfire.Env do
 
       :error ->
         expand_local(meta, fun, args, state, env)
+
+      {:error, :not_found} ->
+        expand_local(meta, fun, args, state, env)
     end
   end
 


### PR DESCRIPTION
I haven't looked deeply into what `Macro.Env.expand_import` can return. Should we perhaps just match on `{:error, _}` to be future-proof?