### PR TITLE
fix: address warnings found by elixir 1.18

### DIFF
--- a/lib/spitfire.ex
+++ b/lib/spitfire.ex
@@ -2575,17 +2575,8 @@ defmodule Spitfire do
   #       arg
   #     )
   # will have 1 newling due to the newline after the opening paren
-  defp get_newlines(parser, kind \\ :peek)
-
-  defp get_newlines(parser, :peek) do
+  defp get_newlines(parser) do
     case peek_newlines(parser) do
-      nil -> []
-      nl -> [newlines: nl]
-    end
-  end
-
-  defp get_newlines(parser, :current) do
-    case current_newlines(parser) do
       nil -> []
       nl -> [newlines: nl]
     end

--- a/lib/spitfire/env.ex
+++ b/lib/spitfire/env.ex
@@ -316,10 +316,7 @@ defmodule Spitfire.Env do
       {:function, module, fun} ->
         expand_remote(meta, module, fun, args, state, env)
 
-      :error ->
-        expand_local(meta, fun, args, state, env)
-
-      {:error, :not_found} ->
+      {:error, _} ->
         expand_local(meta, fun, args, state, env)
     end
   end


### PR DESCRIPTION
This PR addresses two warnings that I'm seeing running spitfire on Elixir 1.18:

![image](https://github.com/user-attachments/assets/6b725acc-251b-4b8b-ba24-80c59928486e)

It doesn't fix any of the currently-failing tests on 1.18, but it doesn't introduce any new ones either (I'm seeing 10 failing tests on main and on this branch). All tests pass on 1.17 with these changes.