### PR TITLE
Fix some dialyzer issues

### DIFF
--- a/lib/spitfire.ex
+++ b/lib/spitfire.ex
@@ -634,7 +634,6 @@ defmodule Spitfire do
 
   defp parse_comma_list(parser, precedence, is_list, is_map) do
     trace "parse_comma_list", trace_meta(parser) do
-      precedence = precedence || @list_comma
       {front, parser} = parse_expression(parser, precedence, is_list, is_map, false)
       # we zip together the expression and parser state so that we can potentially 
       # backtrack later

--- a/lib/spitfire.ex
+++ b/lib/spitfire.ex
@@ -2160,9 +2160,6 @@ defmodule Spitfire do
       case code
            |> String.to_charlist()
            |> :spitfire_tokenizer.tokenize(opts[:line] || 1, opts[:column] || 1, opts) do
-        {:ok, _, _, _, tokens} ->
-          tokens
-
         {:ok, line, column, _, rev_tokens, rev_terminators} ->
           # vendored from elixir-lang/elixir, license: Apache2
           {rev_tokens, rev_terminators} =

--- a/lib/spitfire.ex
+++ b/lib/spitfire.ex
@@ -2355,7 +2355,7 @@ defmodule Spitfire do
   defp eat_at(%{tokens: remaining_tokens} = parser, tokens, idx) when is_list(remaining_tokens) and is_map(tokens) do
     tokens =
       if tokens[Enum.at(remaining_tokens, idx)] do
-        List.delete_at(tokens, idx)
+        List.delete_at(remaining_tokens, idx)
       else
         remaining_tokens
       end


### PR DESCRIPTION
Besides those two, dialyzer is also complaining that those will never match
```
  defp eat_at(parser, token, 0) when is_atom(token) do
    eat(%{token => true}, parser)
  end

  defp eat_at(parser, token, idx) when is_atom(token) do
    eat_at(parser, %{token => true}, idx)
  end
```