### PR TITLE
fix: make spitfire compile on elixir 1.13

### DIFF
--- a/lib/spitfire/env.ex
+++ b/lib/spitfire/env.ex
@@ -2,14 +2,26 @@ defmodule Spitfire.Env do
   @moduledoc """
   Environment querying
   """
-  @env %{
-    Macro.Env.prune_compile_info(__ENV__)
-    | line: 0,
-      file: "nofile",
-      module: nil,
-      function: nil,
-      context_modules: []
-  }
+  @env (if function_exported?(Macro.Env, :prune_compile_info, 1) do
+          %{
+            Macro.Env.prune_compile_info(__ENV__)
+            | line: 0,
+              file: "nofile",
+              module: nil,
+              function: nil,
+              context_modules: []
+          }
+        else
+          %{
+            __ENV__
+            | line: 0,
+              file: "nofile",
+              module: nil,
+              function: nil,
+              context_modules: []
+          }
+        end)
+
   defp env, do: @env
 
   @typedoc "Alias for `Macro.t()`"
@@ -52,7 +64,8 @@ defmodule Spitfire.Env do
   Please see the tests for example usage.
   """
   @spec expand(Macro.t(), String.t()) ::
-          {ast :: ast(), final_state :: state(), final_env :: final_env(), cursor_env :: cursor_env()}
+          {ast :: ast(), final_state :: state(), final_env :: final_env(),
+           cursor_env :: cursor_env()}
   def expand(ast, file) do
     env = env()
 
@@ -63,8 +76,7 @@ defmodule Spitfire.Env do
         %{env | file: file}
       )
 
-    {cursor_state, cursor_env} =
-      Process.get(:cursor_env, {Map.new(), env()})
+    {cursor_state, cursor_env} = Process.get(:cursor_env, {Map.new(), env()})
 
     cursor_env =
       Map.merge(
@@ -73,7 +85,9 @@ defmodule Spitfire.Env do
           functions:
             Enum.filter(Map.get(state, :functions, []), fn {m, _} -> m == cursor_env.module end) ++
               cursor_env.functions,
-          macros: Enum.filter(Map.get(state, :macros, []), fn {m, _} -> m == cursor_env.module end) ++ cursor_env.macros,
+          macros:
+            Enum.filter(Map.get(state, :macros, []), fn {m, _} -> m == cursor_env.module end) ++
+              cursor_env.macros,
           attrs: Enum.uniq(Map.get(cursor_state, :attrs, [])),
           variables: for({name, nil} <- cursor_env.versioned_vars, do: name)
         }
@@ -266,7 +280,8 @@ defmodule Spitfire.Env do
 
   ## Remote call
 
-  defp expand({{:., dot_meta, [module, fun]}, meta, args}, state, env) when is_atom(fun) and is_list(args) do
+  defp expand({{:., dot_meta, [module, fun]}, meta, args}, state, env)
+       when is_atom(fun) and is_list(args) do
     {module, state, env} = expand(module, state, env)
     arity = length(args)
 
@@ -344,7 +359,8 @@ defmodule Spitfire.Env do
   # For the language server, we only want to capture definitions,
   # we don't care when they are used.
 
-  defp expand({var, meta, ctx} = ast, state, %{context: :match} = env) when is_atom(var) and is_atom(ctx) do
+  defp expand({var, meta, ctx} = ast, state, %{context: :match} = env)
+       when is_atom(var) and is_atom(ctx) do
     ctx = Keyword.get(meta, :context, ctx)
     vv = Map.update(env.versioned_vars, var, ctx, fn _ -> ctx end)
 
@@ -385,7 +401,8 @@ defmodule Spitfire.Env do
     end
   end
 
-  defp expand_macro(_meta, Kernel, type, args, _callback, state, env) when type in [:def, :defmacro, :defp, :defmacrop] do
+  defp expand_macro(_meta, Kernel, type, args, _callback, state, env)
+       when type in [:def, :defmacro, :defp, :defmacrop] do
     # extract the name, params, guards, and blocks
     {name, params, guards, blocks} =
       case args do
@@ -432,7 +449,12 @@ defmodule Spitfire.Env do
 
     funcs =
       if is_atom(name) do
-        Map.update(state[state_key], env.module, [{name, arity}], &Keyword.put_new(&1, name, arity))
+        Map.update(
+          state[state_key],
+          env.module,
+          [{name, arity}],
+          &Keyword.put_new(&1, name, arity)
+        )
       else
         state[state_key]
       end
@@ -440,7 +462,8 @@ defmodule Spitfire.Env do
     {Enum.reverse(blocks), put_in(state[state_key], funcs), env}
   end
 
-  defp expand_macro(meta, Kernel, :@, [{name, _, p}] = args, callback, state, env) when is_list(p) do
+  defp expand_macro(meta, Kernel, :@, [{name, _, p}] = args, callback, state, env)
+       when is_list(p) do
     state = update_in(state.attrs, &[to_string(name) | &1])
     expand_macro_callback(meta, Kernel, :@, args, callback, state, env)
   end


### PR DESCRIPTION
This is maybe a little silly, as spitfire doesn't support 1.13, but this change makes it *compile* on 1.13, which is useful for packages w/ older elixir version support to use igniter.

Would you be amenable to this? https://github.com/getsentry/sentry-elixir/pull/876