### PR TITLE
fix: handle no_fuel_remaining in parse_with_comments

### DIFF
--- a/lib/spitfire.ex
+++ b/lib/spitfire.ex
@@ -173,6 +173,7 @@ defmodule Spitfire do
     case result do
       {:ok, ast} -> {:ok, ast, comments}
       {:error, ast, errors} -> {:error, ast, comments, errors}
+      {:error, :no_fuel_remaining} -> {:error, :no_fuel_remaining}
     end
   after
     Process.delete(:code_formatter_comments)


### PR DESCRIPTION
As the title says

It can be triggered with this:

```elixir
code = ~S'x=%{a: 1 b: %{c: 1}}'
Spitfire.parse_with_comments(code)
```

I will fix the error in a followup PR, this PR just handles the `{:error, :no_fuel_remaining}` case
