### PR TITLE
fix: handle unexpected tokens when parsing stabs

### DIFF
--- a/lib/spitfire.ex
+++ b/lib/spitfire.ex
@@ -1281,6 +1281,8 @@ defmodule Spitfire do
 
   defp parse_anon_function(%{current_token: {:fn, _}} = parser) do
     trace "parse_anon_function", trace_meta(parser) do
+      # Clear any stab_state from outer context - fn creates its own stab scope
+      parser = Map.delete(parser, :stab_state)
       meta = current_meta(parser)
 
       newlines = get_newlines(parser)


### PR DESCRIPTION
Fix #75

The issue was that `stab_state` was leaking into inner stabs, corrupting the parser state and causing the wrong tokens to be handed to `parse_stab_expression`. Resetting the state seems to fix this. The other solution I found was to add a fallback clause to `parse_stab_expression` but that felt too hacky because we were still dealing with corrupt parser state.

Also adds a bunch of tests for stabs to make sure the `stab_state` logic is not breaking anything else
