### PR TITLE
fix: range operator precedence and nested range with ternary step

### DIFF
--- a/test/spitfire_test.exs
+++ b/test/spitfire_test.exs
@@ -1694,6 +1694,22 @@ defmodule SpitfireTest do
       assert Spitfire.parse(code) == s2q(code)
     end
 
+    test "range operator precedence and nested ranges" do
+      codes = [
+        "a..b ++ c",
+        "a..b -- c",
+        "a..b <> c",
+        "a..b..c//d",
+        "1..2..3//4",
+        "a..b//c",
+        "1..10//2"
+      ]
+
+      for code <- codes do
+        assert Spitfire.parse(code) == s2q(code)
+      end
+    end
+
     test "from nx repo" do
       code = ~S'''
       def a,


### PR DESCRIPTION
Fixes one of the errors found by #78

`Spitfire.parse("a..b..c//d")` is producing `a..(b..c//d)` instead of `(a..(b..c))//d`.

This is due to the wrong precedence being used for `@range_op`, and the parsing of nested ranges causing the inner range to consume the `//` operator.