### PR TITLE
fix: parse ellipsis_op as unary operator

### DIFF
--- a/lib/spitfire.ex
+++ b/lib/spitfire.ex
@@ -1806,7 +1806,16 @@ defmodule Spitfire do
 
   defp parse_ellipsis_op(parser) do
     trace "parse_ellipsis_op", trace_meta(parser) do
-      {{:..., current_meta(parser), []}, parser}
+      peek = peek_token_type(parser)
+
+      if MapSet.member?(@terminals_with_comma, peek_token(parser)) or peek == :stab_op do
+        {{:..., current_meta(parser), []}, parser}
+      else
+        meta = current_meta(parser)
+        parser = next_token(parser)
+        {rhs, parser} = parse_expression(parser, @lowest, false, false, false)
+        {{:..., meta, [rhs]}, parser}
+      end
     end
   end
 

--- a/test/spitfire_test.exs
+++ b/test/spitfire_test.exs
@@ -2076,6 +2076,18 @@ defmodule SpitfireTest do
       '''
 
       assert Spitfire.parse(code) == s2q(code)
+
+      code = ~S'''
+      ... + 1 * 2
+      '''
+
+      assert Spitfire.parse(code) == s2q(code)
+
+      code = ~S'''
+      @type fun :: (... -> any())
+      '''
+
+      assert Spitfire.parse(code) == s2q(code)
     end
 
     test "blocks inside an anon function as a parameter" do


### PR DESCRIPTION
`... + 1 * 2` is not parsed the same as with the elixir parser

Spitfire:
```elixir
{:+, [line: 1, column: 5], [{:..., [line: 1, column: 1], []}, {:*, [line: 1, column: 9], [1, 2]}]}
```
Elixir:
```elixir
{:+, [line: 1, column: 5], [{:..., [line: 1, column: 1], []}, {:*, [line: 1, column: 9], [1, 2]}]}
```

The problem was that `...` was parsed as an empty node, like the ones occurring at typespecs (eg `@type foo :: [atom(), ...]`) but never as a unary operator.
The fix is to consider it a unary_op if it's not followed by a terminal, then parse the right hand side.