### PR TITLE
fix: extract newlines only from newline carrying tokens

### DIFF
--- a/lib/spitfire.ex
+++ b/lib/spitfire.ex
@@ -2800,11 +2800,36 @@ defmodule Spitfire do
     nil
   end
 
-  defp current_newlines(%{current_token: {_token, {_line, _col, newlines}, _}}) when is_integer(newlines) do
+  @newline_carrying_tokens [
+    :eol,
+    :assoc_op,
+    :ternary_op,
+    :power_op,
+    :range_op,
+    :concat_op,
+    :arrow_op,
+    :comp_op,
+    :rel_op,
+    :and_op,
+    :or_op,
+    :xor_op,
+    :in_match_op,
+    :type_op,
+    :stab_op,
+    :mult_op,
+    :match_op,
+    :pipe_op,
+    :when_op,
+    :in_op
+  ]
+
+  defp current_newlines(%{current_token: {token, {_line, _col, newlines}, _}})
+       when token in @newline_carrying_tokens and is_integer(newlines) do
     newlines
   end
 
-  defp current_newlines(%{current_token: {_token, {_line, _col, newlines}}}) when is_integer(newlines) do
+  defp current_newlines(%{current_token: {token, {_line, _col, newlines}}})
+       when token in @newline_carrying_tokens and is_integer(newlines) do
     newlines
   end
 

--- a/test/spitfire_test.exs
+++ b/test/spitfire_test.exs
@@ -717,6 +717,9 @@ defmodule SpitfireTest do
         %Bar.__MODULE__.Foo{
           bar: "foo"
         }
+        ''',
+        ~S'''
+        %Foo{"ok": 1}
         '''
       ]
 


### PR DESCRIPTION
We were assuming that a third integer element in the token tuple were always newlines, but they can sometimes be other things, like a delimiter character codepoint.

This caused the `:newlines` metadata to be attached to nodes that should not have it. This caused a mismatch between what Spitfire produces and what the Elixir parser produces.

`%Foo{"ok": 1}` was the smallest example I found to trigger this bug.