### PR TITLE
fix: improve handling of matched/unmatched expressions

### DIFF
--- a/test/spitfire_test.exs
+++ b/test/spitfire_test.exs
@@ -2163,6 +2163,16 @@ defmodule SpitfireTest do
         assert Spitfire.parse(code) == s2q(code)
       end
     end
+
+    test "operators on unmatched expression" do
+      code = ~S'''
+      +case a do
+        _ -> b
+      end |> c ** d >>> e
+      '''
+
+      assert Spitfire.parse(code) == s2q(code)
+    end
   end
 
   describe "code with errors" do


### PR DESCRIPTION
Unary operators behave differently depending on wether they are applied to a matched or unmatched expression in Elixir's grammar. Calls with do/end blocks are unmatched expressions, and Elixir allows unary operators to wrap a full expression in that position, not just the immediate block.

Spitfire doesn't make that distinction, it always parses the unary operand at unary precedence, making it bind too tightly when the operand is an unparenthesized do/end block.

So, this code from the tests in #78:
`+case a do _ -> b end |> c ** d >>> e`

Is parsed like this by Spitfire:
`(+(case a do _ -> b end) |> c ** d) >>> e`

But Elixir parses it like this:
`+(case a do _ -> b end |> c ** d >>> e)`

The fix is to detect when the unary operand is an unparenthesized do/end block and reparse the RHS with the lowest precedence, making the unary operand a full expression, forcing it to behave like Elixir.

More generally, we probably want to make the distinction more explicit in Spitfires' parser, but for now I'm fixing one issue at a time to achieve parity with Elixir first and have a baseline for more improvements.