### PR TITLE
fix: associativity in bracketless kw list

### DIFF
--- a/lib/spitfire.ex
+++ b/lib/spitfire.ex
@@ -666,7 +666,7 @@ defmodule Spitfire do
       token = encode_literal(parser, token, meta)
       parser = parser |> next_token() |> eat_eoe()
 
-      {value, parser} = parse_expression(parser, @kw_identifier, false, false, false)
+      {value, parser} = parse_expression(parser, @list_comma, false, false, false)
 
       {kvs, parser} = parse_kw_list_continuation(parser)
 
@@ -688,7 +688,7 @@ defmodule Spitfire do
             {t, meta, args}
         end
 
-      {value, parser} = parse_expression(parser, @kw_identifier, false, false, false)
+      {value, parser} = parse_expression(parser, @list_comma, false, false, false)
 
       {kvs, parser} = parse_kw_list_continuation(parser)
 

--- a/test/spitfire_test.exs
+++ b/test/spitfire_test.exs
@@ -2173,6 +2173,12 @@ defmodule SpitfireTest do
 
       assert Spitfire.parse(code) == s2q(code)
     end
+
+    test "when in bracketless kw list" do
+      code = ~S'with a <- b, do: c when a'
+
+      assert Spitfire.parse(code) == s2q(code)
+    end
   end
 
   describe "code with errors" do


### PR DESCRIPTION
In the elixir parser there is a rule that allows `when` to bind to a bracketless keyword list(`no_parens_op_expr` -> `when_op_eol call_args_no_parens_kw`).

Spitfire doesn't have that rule, so this code:

`+with a <- b, do: c when a` (from property tests)

parses incorrectly as:

```elixir
{
  :+,
  [line: 1, column: 1],
  [
    {
      :with,
      [line: 1, column: 2],
      [
        {
          :<-,
          [line: 1, column: 9],
          [{:a, [line: 1, column: 7], nil}, {:b, [line: 1, column: 12], nil}]
        },
        {:when, [line: 1, column: 21], [[do: {:c, [line: 1, column: 19], nil}], {:a, [line: 1, column: 26], nil}]}
      ]
    }
  ]
}
```

when Elixir produces this:

```elixir
{
  :+,
  [line: 1, column: 1],
  [
    {
      :with,
      [line: 1, column: 2],
      [
        {
          :<-,
          [line: 1, column: 9],
          [{:a, [line: 1, column: 7], nil}, {:b, [line: 1, column: 12], nil}]
        },
        [do: {:when, [line: 1, column: 21], [{:c, [line: 1, column: 19], nil}, {:a, [line: 1, column: 26], nil}]}]
      ]
    }
  ]
}
```

The fix here is the same as #85, we need to use `@list_comma` to ensure the correct associativity for them.