### PR TITLE
fix: rearrange `!(left) in right`

### DIFF
--- a/lib/spitfire.ex
+++ b/lib/spitfire.ex
@@ -1012,6 +1012,16 @@ defmodule Spitfire do
           :"not in" ->
             {:not, meta, [{:in, meta, [lhs, rhs]}]}
 
+          :in ->
+            case lhs do
+              {op, _meta, [inner]} when op in [:!, :not] ->
+                in_ast = {:in, meta, [inner, rhs]}
+                {op, meta, [in_ast]}
+
+              _ ->
+                {token, newlines ++ meta, [lhs, rhs]}
+            end
+
           :when ->
             lhs =
               case lhs do


### PR DESCRIPTION
The Elixir parser rewrites `(!left) in right` into `!(left in right)`, regardless of operator precedence. This rule does not exist in Spitfire, causing a discrepancy in the generated ast.

Spitfire:
```elixir
{:in, _, [{:!, _, [left]}, right]}
```
Elixir:
```elixir
{:!, _, [{:in, _, [left, right]}]}
```

The fix is to add a clause for this rearrangement like the one in the Elixir parser [here](https://github.com/elixir-lang/elixir/blob/c40c140e3f524fa8384efd33137ec1c3fab341d3/lib/elixir/src/elixir_parser.yrl#L749-L756)