### PR TITLE
fix: add `:eof` to the terminator list in `parse_stab_expression/1`

### DIFF
--- a/lib/spitfire.ex
+++ b/lib/spitfire.ex
@@ -1112,7 +1112,7 @@ defmodule Spitfire do
       parser = Map.put(parser, :nesting, 0)
 
       {exprs, parser} =
-        while2 peek_token(parser) not in [:end, :")", :block_identifier] <- parser do
+        while2 peek_token(parser) not in [:end, :eof, :")", :block_identifier] <- parser do
           parser = parser |> next_token() |> eat_eoe()
           {ast, parser} = parse_expression(parser, @lowest, false, false, true)
 

--- a/test/spitfire_test.exs
+++ b/test/spitfire_test.exs
@@ -3444,6 +3444,27 @@ defmodule SpitfireTest do
                     {:k, [line: 1, column: 49], nil}}
                  ]}, [{[line: 1, column: 46], "syntax error"}]}
     end
+
+    test "stab expression with fn and stray closing delimiter does not exhaust fuel" do
+      assert Spitfire.parse("a -> b -> fn} -> c") ==
+               {:error,
+                [
+                  {:->, [line: 1, column: 3], [[{:a, [line: 1, column: 1], nil}], nil]},
+                  {:->, [line: 1, column: 8],
+                   [
+                     [],
+                     {:fn, [line: 1, column: 11],
+                      [
+                        {:__block__, [error: true, line: 1, column: 13], []},
+                        {:->, [line: 1, column: 15], [[], {:c, [line: 1, column: 18], nil}]}
+                      ]}
+                   ]}
+                ],
+                [
+                  {[line: 1, column: 13], "unknown token: }"},
+                  {[line: 1, column: 11], "missing closing end for anonymous function"}
+                ]}
+    end
   end
 
   describe "&parse_with_comments/2" do


### PR DESCRIPTION
resolves #90 

As I understand, the problems lies in the terminating list when doing `while2`. 
In the given example in the issue, the loop continues, peek becomes `->`, then `c`, then `:eof`. At that point, without `:eof` in the terminator list, the loop would continue infinitely.

If im completely off, feel free to close this PR. 

Keep up the good work! 