### PR TITLE
fix: align ellipsis operator precedence with elixir

### DIFF
--- a/lib/spitfire.ex
+++ b/lib/spitfire.ex
@@ -2570,10 +2570,12 @@ defmodule Spitfire do
     trace "parse_ellipsis_op", trace_meta(parser) do
       peek = peek_token_type(parser)
 
-      # `...` is standalone when followed by a terminal, stab op, or keyword
+      # `...` is standalone when followed by a terminal, stab op, keyword
+      # or binary operators (except :dual_op)
       if MapSet.member?(@terminals_with_comma, peek_token(parser)) or
            peek_token(parser) == :";" or
-           peek in [:stab_op, :do, :end, :block_identifier] do
+           peek in [:stab_op, :do, :end, :block_identifier] or
+           (is_binary_op?(peek) and peek != :dual_op) do
         {{:..., current_meta(parser), []}, parser}
       else
         meta = current_meta(parser)


### PR DESCRIPTION
Based on https://github.com/elixir-tools/spitfire/pull/81 and fixes the failing tests.

- Treat `...` as a standalone term before binary operators (like ranges).
- Allow `...` to consume unary `+`/`-` so arithmetic precedence matches Elixir.
- Tests now pass for ellipsis operator precedence cases.

There were 3 failing tests:

```elixir
  1) test ... operator - unary ellipsis as term before range (Spitfire.OperatorsTest)
     test/operators_test.exs:1038
     Assertion with == failed
     code:  assert spitfire_parse(code) == s2q(code)
     left:  {:error, :parse_error}
     right: {:ok, {:.., [line: 1, column: 5], [{:..., [line: 1, column: 1], []}, 1]}}
     stacktrace:
       test/operators_test.exs:1040: (test)

  2) test ... operator - unary ellipsis as term before infix operator (Spitfire.OperatorsTest)
     test/operators_test.exs:1033
     Assertion with == failed
     code:  assert spitfire_parse(code) == s2q(code)
     left:  {:error, :parse_error}
     right: {:ok, {:*, [line: 1, column: 5], [{:..., [line: 1, column: 1], []}, 1]}}
     stacktrace:
       test/operators_test.exs:1035: (test)


  3) test ... operator - unary = has higher precedence than ... (Spitfire.OperatorsTest)
     test/operators_test.exs:1018
     Assertion with == failed
     code:  assert spitfire_parse(code) == s2q(code)
     left:  {:error, :parse_error}
     right: {
              :ok,
              {:=, [line: 1, column: 5], [{:..., [line: 1, column: 1], []}, {:=, [line: 1, column: 9], [{:a, [line: 1, column: 7], nil}, {:b, [line: 1, column: 11], nil}]}]}
            }
     stacktrace:
       test/operators_test.exs:1020: (test)
```