### PR TITLE
fix: parse nested struct/map targets in struct literals

### DIFF
--- a/lib/spitfire.ex
+++ b/lib/spitfire.ex
@@ -2790,6 +2790,12 @@ defmodule Spitfire do
           :atom_quoted ->
             parse_atom(parser)
 
+          :%{} ->
+            parse_map_literal(parser)
+
+          :% ->
+            parse_struct_literal(parser)
+
           :"(" ->
             parse_grouped_expression(parser)
 

--- a/test/spitfire_test.exs
+++ b/test/spitfire_test.exs
@@ -2290,6 +2290,9 @@ defmodule SpitfireTest do
       assert Spitfire.parse("%false{}") == s2q("%false{}")
       assert Spitfire.parse("%true{}") == s2q("%true{}")
 
+      # Struct arg inside struct arg
+      assert Spitfire.parse("%%{}{}") == s2q("%%{}{}")
+
       # In-match operator (<-) in map keys - should be part of key, not wrap it
       assert Spitfire.parse("%{s\\\\r => 1}") == s2q("%{s\\\\r => 1}")
     end


### PR DESCRIPTION
Allow struct-type parsing to accept map and struct literals (:%{} and :%) as valid struct targets.

This fixes cases like %%{}{} where Elixir produces a valid AST but Spitfire previously emitted unknown-token errors because parse_struct_type/1 rejected %{} as a type expression.