### PR TITLE
fix: support dot-call struct targets like %e.(){}

### DIFF
--- a/lib/spitfire.ex
+++ b/lib/spitfire.ex
@@ -2871,10 +2871,7 @@ defmodule Spitfire do
       current_type = current_token_type(parser)
 
       if current_type == :dot_call_op do
-        # dot_call_op means . followed by ()
-        # Just produce the dot with lhs, the () will be handled by the while loop
-        parser = next_token(parser)
-        {{:., meta, [lhs]}, parser}
+        parse_dot_call_expression(parser, lhs)
       else
         case peek_token_type(parser) do
           :alias ->

--- a/test/spitfire_test.exs
+++ b/test/spitfire_test.exs
@@ -2295,6 +2295,11 @@ defmodule SpitfireTest do
 
       # In-match operator (<-) in map keys - should be part of key, not wrap it
       assert Spitfire.parse("%{s\\\\r => 1}") == s2q("%{s\\\\r => 1}")
+
+      # Struct type with dot-call target
+      assert Spitfire.parse("%e.(){}") == s2q("%e.(){}")
+      assert Spitfire.parse("%e.(1){}") == s2q("%e.(1){}")
+      assert Spitfire.parse("%e.(a, b){}") == s2q("%e.(a, b){}")
     end
   end
 


### PR DESCRIPTION
Struct type parsing handled :dot_call_op by building only a dot node and leaving token position before braces, which caused a missing-opening-brace error for valid input.

Consume the empty call in the struct-type dot-call branch and attach closing metadata so AST matches Elixir for %e.(){}.

Adds a regression assertion in the property test regression block.