### PR TITLE
fix: consume fuel for parsing anon functions

### DIFF
--- a/lib/spitfire.ex
+++ b/lib/spitfire.ex
@@ -2133,6 +2133,8 @@ defmodule Spitfire do
       {exprs, parser} =
         with_context(parser, %{stop_before_stab_op?: true}, fn parser ->
           while2 current_token(parser) not in [:end, :eof] <- parser do
+            parser = consume_fuel(parser)
+
             {ast, parser} =
               case Map.get(parser, :stab_state) do
                 %{ast: lhs} ->

--- a/test/spitfire_test.exs
+++ b/test/spitfire_test.exs
@@ -2356,6 +2356,13 @@ defmodule SpitfireTest do
       assert {:error, _ast, _errors} = Spitfire.parse("fn ->\n)")
     end
 
+    test "fn -> followed by block identifier exhausts fuel instead of hanging" do
+      assert Spitfire.parse("fn -> catch") == {:error, :no_fuel_remaining}
+      assert Spitfire.parse("fn -> after") == {:error, :no_fuel_remaining}
+      assert Spitfire.parse("fn -> rescue") == {:error, :no_fuel_remaining}
+      assert Spitfire.parse("fn -> else") == {:error, :no_fuel_remaining}
+    end
+
     test "missing bitstring brackets" do
       code = """
       <<one::


### PR DESCRIPTION
after reading this comment https://github.com/elixir-tools/spitfire/pull/122#issuecomment-3997345909 i went digging for a way to force an infinite loop. Apparently `fn ->` followed by a block identifier does that, so i added some fuel consumption. 

Is this the way to go or should i try to fix the error so it is fixed by something else than fuel consumption? 