### PR TITLE
fix: don't crash on charlist with pure interpolation

### DIFF
--- a/lib/spitfire.ex
+++ b/lib/spitfire.ex
@@ -2477,7 +2477,7 @@ defmodule Spitfire do
     end
   end
 
-  defp parse_string(%{current_token: {:list_string, meta, [string]}} = parser) do
+  defp parse_string(%{current_token: {:list_string, meta, [string]}} = parser) when is_binary(string) do
     trace "parse_string (list_string)", trace_meta(parser) do
       string = encode_literal(parser, String.to_charlist(string), meta)
       {string, parser}

--- a/test/spitfire_test.exs
+++ b/test/spitfire_test.exs
@@ -200,6 +200,18 @@ defmodule SpitfireTest do
 
       assert Spitfire.parse(code) == s2q(code)
 
+      code = ~S'''
+      '#{alice}'
+      '''
+
+      assert Spitfire.parse(code) == s2q(code)
+
+      code = ~S'''
+      defmodule D, do: '#{alice}'
+      '''
+
+      assert Spitfire.parse(code) == s2q(code)
+
       code = ~S"""
       '''
       foo#{alice}bar


### PR DESCRIPTION
The `:list_string` non-interpolation clause of `parse_string/1` was missing the `when is_binary(string)` guard that the parallel `:bin_string` clause has. When the tokenizer emits a single-element token list for a charlist that contains only an interpolation (e.g. `'#{x}'`), the unguarded clause matches and calls `String.to_charlist/1` on the interpolation-segment tuple, raising `FunctionClauseError`.

Charlists with surrounding text (`'foo#{x}bar'`) were unaffected because their token list has multiple elements and falls through to the interpolation-aware clause.

Fixes #132 