### PR TITLE
fix: correctly parse parentheses around anonymous function arguments

### DIFF
--- a/lib/spitfire.ex
+++ b/lib/spitfire.ex
@@ -1322,7 +1322,10 @@ defmodule Spitfire do
               {:when, [{:parens, _parens} = paren_meta | _], _} ->
                 [paren_meta | meta]
 
-              {type, [{:parens, _parens} = paren_meta | _], _} when type in [:__block__, :comma, :when] ->
+              {:__block__, [{:parens, _parens} = paren_meta], _} ->
+                [paren_meta | meta]
+
+              {type, [{:parens, _parens} = paren_meta | _], _} when type in [:comma, :when] ->
                 [paren_meta | meta]
 
               _ ->
@@ -1345,6 +1348,9 @@ defmodule Spitfire do
 
               {:when, [{:parens, _} | when_meta], when_args} ->
                 [{:when, when_meta, when_args}]
+
+              {:__block__, [{:parens, _}, _ | _] = block_meta, [expr]} ->
+                [{:__block__, block_meta, [expr]}]
 
               {:__block__, [{:parens, _} = paren_meta | _], exprs} ->
                 case exprs do

--- a/test/spitfire_test.exs
+++ b/test/spitfire_test.exs
@@ -2154,6 +2154,23 @@ defmodule SpitfireTest do
       end
     end
 
+    test "literal encoder preserves metadata for grouped patterns in anonymous functions" do
+      encoder = fn literal, meta -> {:ok, {:__block__, meta, [literal]}} end
+
+      for code <- [
+            ~S'fn ({code, _index}) -> code end',
+            ~S'fn ([code, index]) -> code end'
+          ] do
+        assert Spitfire.parse(code, literal_encoder: encoder) ==
+                 Code.string_to_quoted(code,
+                   literal_encoder: encoder,
+                   columns: true,
+                   token_metadata: true,
+                   emit_warnings: false
+                 )
+      end
+    end
+
     test "sigils" do
       codes = [
         ~S'~s"foo"',


### PR DESCRIPTION
This was found via https://github.com/expert-lsp/expert/issues/877

When Spitfire parses a code where anonymous function's arguments are surrounded by parentheses, it produces a different AST than `Code.string_to_quoted`. This theoretically incorrect AST was fed to Sourceror, which resulted in an error reported in the issue in Expert.